### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Learning-Object-Oriented-Python
 ![](https://www.codetriage.com/josharsh/learning-object-oriented-python/badges/users.svg)
-This repository walks you through the Object Oriented Programming in python. Illustrates real world examples, working codes and going about finding a coding solution. 
+This repository walks you through Object Oriented Programming in python. Illustrates real world examples, working codes and going about finding a coding solution. 
 


### PR DESCRIPTION
BEFORE: "This repository walks you through the Object Orientated Programming in python"
AFTER: "This repository walks you through Object Oriented Programming in python"